### PR TITLE
Fix overrun in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,8 +350,8 @@ void loop()
   datas[length+1] = crc_data & 0xff;
   Serial.print("The datas send to the radar: ");
   for (int n = 0; n < length + 2; n++){
-    char buffsend[1];
-    sprintf(buffsend, "0x%02x ", datas[n]);
+    char buffsend[8];
+    snprintf(buffsend, sizeof(buffsend), "0x%02x ", datas[n]);
     Serial.print(buffsend);
   }
   Serial.println();


### PR DESCRIPTION
The README includes an example that allocates a single byte
buffer an sprintf's to that. This might work due to a quirk
with aligning to 8-byte boundaries but "%02x " is always
going to be 2 characters + 2 hex + 1 space + nul (7 characters)
which is a little dicey.

snprintf makes this safer because snprintf accounts for the
buffer length.